### PR TITLE
chore(ci): bump actions/checkout to v7 and actions/setup-node to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         node: [18, 20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
## Summary

Bumps the two GitHub-provided actions in `.github/workflows/test.yml` to the **latest majors**:

- `actions/checkout@v4` → `actions/checkout@v7` (latest: v7.0.0, Jun 2026)
- `actions/setup-node@v4` → `actions/setup-node@v6` (latest: v6.4.0, Apr 2026)

## Why

`@v4` of both actions runs on Node.js 20, which was deprecated on GitHub Actions runners and is now force-run on Node.js 24, producing this warning on every workflow run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

Both new majors target Node.js 24 natively (since v5), eliminating the warning.

## Why latest (v7 / v6) and not the minimum v5 bump

v5 of each action is the minimum required to fix the Node 20 deprecation. Going straight to the latest major is preferred here because **neither breaking change affects this workflow**:

| Action | Breaking change in new major | Affects us? |
|---|---|---|
| `actions/checkout@v7` | Persists creds to a separate file; blocks fork-PR checkout for `pull_request_target` and `workflow_run` triggers | No — this workflow only triggers on `push` and `pull_request` |
| `actions/setup-node@v6` | Limits automatic caching to npm only | No — this workflow does not use the `cache` input |

Also picks up ESM migration and various dependency/security updates in `actions/checkout@v7`.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Scope

Workflow-only change. No source code or built artifact touched. Separate from #121.